### PR TITLE
Renamed String class to Strings - fixes compatibility with php7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ php:
   - 5.6
   - 7.0
 
-matrix:
-    allow_failures:
-        - php: 7.0
-
 before_script:
   - composer self-update
   - composer install --no-interaction --prefer-source

--- a/src/FioRead.php
+++ b/src/FioRead.php
@@ -36,7 +36,7 @@ class FioRead extends Fio
      */
     public function movements($from = '-1 week', $to = 'now')
     {
-        $data = $this->download('periods/%s/%s/%s/transactions.%s', Utils\String::date($from), Utils\String::date($to), $this->parser->getExtension());
+        $data = $this->download('periods/%s/%s/%s/transactions.%s', Utils\Strings::date($from), Utils\Strings::date($to), $this->parser->getExtension());
         return $this->parser->parse($data);
     }
 
@@ -86,7 +86,7 @@ class FioRead extends Fio
      */
     public function setLastDate($date)
     {
-        $this->download('set-last-date/%s/%s/', Utils\String::date($date));
+        $this->download('set-last-date/%s/%s/', Utils\Strings::date($date));
     }
 
     /**

--- a/src/Request/Pay/Payment/Euro.php
+++ b/src/Request/Pay/Payment/Euro.php
@@ -83,7 +83,7 @@ class Euro extends Property
      */
     public function setStreet($str)
     {
-        $this->benefStreet = Utils\String::substr($str, 35);
+        $this->benefStreet = Utils\Strings::substr($str, 35);
         return $this;
     }
 
@@ -94,7 +94,7 @@ class Euro extends Property
      */
     public function setCity($str)
     {
-        $this->benefCity = Utils\String::substr($str, 35);
+        $this->benefCity = Utils\Strings::substr($str, 35);
         return $this;
     }
 
@@ -120,7 +120,7 @@ class Euro extends Property
      */
     public function setName($name)
     {
-        $this->benefName = Utils\String::substr($name, 35);
+        $this->benefName = Utils\Strings::substr($name, 35);
         return $this;
     }
 
@@ -131,7 +131,7 @@ class Euro extends Property
      */
     public function setRemittanceInfo1($str)
     {
-        $this->remittanceInfo1 = Utils\String::substr($str, 35);
+        $this->remittanceInfo1 = Utils\Strings::substr($str, 35);
         return $this;
     }
 
@@ -142,7 +142,7 @@ class Euro extends Property
      */
     public function setRemittanceInfo2($str)
     {
-        $this->remittanceInfo2 = Utils\String::substr($str, 35);
+        $this->remittanceInfo2 = Utils\Strings::substr($str, 35);
         return $this;
     }
 
@@ -153,7 +153,7 @@ class Euro extends Property
      */
     public function setRemittanceInfo3($str)
     {
-        $this->remittanceInfo3 = Utils\String::substr($str, 35);
+        $this->remittanceInfo3 = Utils\Strings::substr($str, 35);
         return $this;
     }
 

--- a/src/Request/Pay/Payment/International.php
+++ b/src/Request/Pay/Payment/International.php
@@ -58,7 +58,7 @@ class International extends Euro
      */
     public function setRemittanceInfo4($str)
     {
-        $this->remittanceInfo4 = Utils\String::substr($str, 35);
+        $this->remittanceInfo4 = Utils\Strings::substr($str, 35);
         return $this;
     }
 

--- a/src/Request/Pay/Payment/National.php
+++ b/src/Request/Pay/Payment/National.php
@@ -47,13 +47,13 @@ class National extends Property
      */
     public function setMessage($str)
     {
-        $this->messageForRecipient = Utils\String::substr($str, 140);
+        $this->messageForRecipient = Utils\Strings::substr($str, 140);
         return $this;
     }
 
     public function setAccountTo($accountTo, $bankCode = NULL)
     {
-        $accountObject = Utils\String::createAccount($accountTo, $bankCode);
+        $accountObject = Utils\Strings::createAccount($accountTo, $bankCode);
         $this->accountTo = $accountObject->getAccount();
         $this->bankCode = $accountObject->getBankCode();
         return $this;

--- a/src/Request/Pay/Payment/Property.php
+++ b/src/Request/Pay/Payment/Property.php
@@ -58,7 +58,7 @@ abstract class Property implements Iterator
      */
     public function __construct($account)
     {
-        $accountObject = Utils\String::createAccount($account);
+        $accountObject = Utils\Strings::createAccount($account);
         $this->accountFrom = $accountObject->getAccount();
         $this->setDate('now');
     }
@@ -112,7 +112,7 @@ abstract class Property implements Iterator
      */
     public function setMyComment($str)
     {
-        $this->comment = Utils\String::substr($str, 255);
+        $this->comment = Utils\Strings::substr($str, 255);
         return $this;
     }
 

--- a/src/Response/Read/ATransaction.php
+++ b/src/Response/Read/ATransaction.php
@@ -86,7 +86,7 @@ abstract class ATransaction implements \Iterator
 				}
 				return intval($value);
 			case 'datetime':
-				return Utils\String::createFromFormat($value, $this->getDateFormat());
+				return Utils\Strings::createFromFormat($value, $this->getDateFormat());
 			case 'float':
 				return floatval($value);
 			case 'string':

--- a/src/Response/Read/JsonStatementFactory.php
+++ b/src/Response/Read/JsonStatementFactory.php
@@ -27,8 +27,8 @@ class JsonStatementFactory implements IStatementFactory
 
 	public function createInfo($data, $dateFormat)
 	{
-		$data->dateStart = Utils\String::createFromFormat($data->dateStart, $dateFormat);
-		$data->dateEnd = Utils\String::createFromFormat($data->dateEnd, $dateFormat);
+		$data->dateStart = Utils\Strings::createFromFormat($data->dateStart, $dateFormat);
+		$data->dateEnd = Utils\Strings::createFromFormat($data->dateEnd, $dateFormat);
 		return $data;
 	}
 

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -7,7 +7,7 @@ use Nette\Utils\DateTime;
 /**
  * @author Milan Matějček
  */
-final class String
+final class Strings
 {
 
     private function __construct()


### PR DESCRIPTION
`String` is reserved word in PHP7