### PR TITLE
Euro BIC jako nepovinny parametr

### DIFF
--- a/src/FioPay.php
+++ b/src/FioPay.php
@@ -43,7 +43,7 @@ class FioPay extends Fio
 	}
 
 
-	public function createEuro(float $amount, string $accountTo, string $name, string $bic = ''): Pay\Payment\Euro
+	public function createEuro(float $amount, string $accountTo, string $name, ?string $bic = null): Pay\Payment\Euro
 	{
 		$account = Bank::createInternational($accountTo);
 		if ($bic === '') {
@@ -71,7 +71,7 @@ class FioPay extends Fio
 	}
 
 
-	public function createInternational(float $amount, string $accountTo, string $name, string $street, string $city, string $country, string $info, string $bic = ''): Pay\Payment\International
+	public function createInternational(float $amount, string $accountTo, string $name, string $street, string $city, string $country, string $info, ?string $bic = null): Pay\Payment\International
 	{
 		$account = Bank::createInternational($accountTo);
 		if ($bic === '') {

--- a/src/Request/Pay/Payment/Foreign.php
+++ b/src/Request/Pay/Payment/Foreign.php
@@ -50,11 +50,13 @@ abstract class Foreign extends Property
 
 
 	/**
-	 * @param string $bic ISO 9362
+	 * @param null|string $bic ISO 9362
+     * @return $this
 	 */
-	public function setBic(string $bic)
+	public function setBic(?string $bic)
 	{
-		$this->bic = InvalidArgument::checkLength($bic, 11);
+        # pri false bude hodnota preskocena
+	    $this->bic = (is_null($bic)) ? false : InvalidArgument::checkLength($bic, 11);
 		return $this;
 	}
 


### PR DESCRIPTION
Ve FIO API doc je BIC parametr jako nepovinný. Hodilo by se mi, kdyby nebylo nutné jej zadávat ani v knihovně. Pokud by byla hodnota NULL, parametr bude přeskočen. Pokud je hodnota jiná, je parametr validován na 11 znaků.