### PR TITLE
PHP 8.0, type hints, PHPStan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,16 @@
 language: php
 php:
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
   - 8.0
-
-jobs:
-  allow_failures:
-    - php: 8.0
+  - 8.1
+  - 8.2
 
 before_script:
   - composer self-update
-  - if [ "$TRAVIS_PHP_VERSION" == "7.4" ]; then NTESTER_FLAGS="phpdbg --coverage ./coverage.xml --coverage-src ./src"; else TESTER_FLAGS=""; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "8.0" ]; then NTESTER_FLAGS="phpdbg --coverage ./coverage.xml --coverage-src ./src"; else TESTER_FLAGS=""; fi
 
 
 after_script:
-  - if [ "$TRAVIS_PHP_VERSION" == "7.4" ]; then
+  - if [ "$TRAVIS_PHP_VERSION" == "8.0" ]; then
     wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar
     && php coveralls.phar --verbose --config tests/.coveralls.yml
     || true;

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Support [Fio API](http://www.fio.sk/docs/cz/API_Bankovnictvi.pdf). Read is provi
 
 Here is [changlog](changelog.md)
 
+- PHP 8.0+ let's use version 3.0+
 - PHP 7.1+ let's use version 2.0+
 - PHP 5.5 - 7.0 let's use stable [version 1.3.5](https://github.com/h4kuna/fio/releases/tag/v1.3.5).
 - PHP 5.3 - 5.4 let's use stable [version 1.2.1](https://github.com/h4kuna/fio/releases/tag/v1.2.1).

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php-64bit": ">=7.1",
+    "php-64bit": ">=8.0",
     "ext-mbstring": "*",
     "ext-xmlwriter": "*",
     "ext-simplexml": "*",
@@ -22,7 +22,7 @@
   },
   "require-dev": {
     "salamium/testinium": "^0.1",
-    "phpstan/phpstan": "^0.12"
+    "phpstan/phpstan": "^1.9"
   },
   "autoload": {
     "psr-4": {

--- a/src/Account/AccountCollection.php
+++ b/src/Account/AccountCollection.php
@@ -11,7 +11,7 @@ use h4kuna\Fio\Exceptions;
 class AccountCollection implements \Countable, \IteratorAggregate
 {
 	/** @var array<FioAccount> */
-	private $accounts = [];
+	private array $accounts = [];
 
 
 	public function account(string $alias = ''): FioAccount

--- a/src/Account/AccountCollectionFactory.php
+++ b/src/Account/AccountCollectionFactory.php
@@ -14,9 +14,9 @@ class AccountCollectionFactory
 	{
 		$accountCollection = new AccountCollection;
 		foreach ($accounts as $alias => $info) {
-			if (!isset($info['token'])) {
+			if (!isset($info['token'])) { /* @phpstan-ignore-line */
 				throw new Exceptions\InvalidArgument(sprintf('Key "token" is required for alias "%s".', $alias));
-			} elseif (!isset($info['account'])) {
+			} elseif (!isset($info['account'])) { /* @phpstan-ignore-line */
 				throw new Exceptions\InvalidArgument(sprintf('Key "account" is required for alias "%s".', $alias));
 			}
 			$accountCollection->addAccount($alias, new FioAccount($info['account'], $info['token']));

--- a/src/Account/Bank.php
+++ b/src/Account/Bank.php
@@ -6,14 +6,11 @@ use h4kuna\Fio\Exceptions\InvalidArgument;
 
 class Bank
 {
-	/** @var string */
-	private $account;
+	private string $account;
 
-	/** @var string */
-	private $bankCode = '';
+	private string $bankCode;
 
-	/** @var string */
-	private $prefix = '';
+	private string $prefix;
 
 
 	private function __construct(string $account, string $bankCode, string $prefix)
@@ -50,7 +47,7 @@ class Bank
 
 	public function __toString()
 	{
-		return (string) $this->getAccount();
+		return $this->getAccount();
 	}
 
 

--- a/src/Account/FioAccount.php
+++ b/src/Account/FioAccount.php
@@ -4,11 +4,9 @@ namespace h4kuna\Fio\Account;
 
 class FioAccount
 {
-	/** @var Bank */
-	private $account;
+	private Bank $account;
 
-	/** @var string */
-	private $token;
+	private string $token;
 
 
 	public function __construct(string $account, string $token)

--- a/src/Exceptions/InvalidArgument.php
+++ b/src/Exceptions/InvalidArgument.php
@@ -24,7 +24,7 @@ final class InvalidArgument extends \InvalidArgumentException
 
 
 	/**
-	 * @template T
+	 * @template T of string|int
 	 * @param T $value
 	 * @param array<T> $list
 	 * @return T

--- a/src/Fio.php
+++ b/src/Fio.php
@@ -19,11 +19,9 @@ class Fio
 	 */
 	const FIO_API_VERSION = '1.5.1';
 
-	/** @var Request\IQueue */
-	protected $queue;
+	protected Request\IQueue $queue;
 
-	/** @var Account\FioAccount */
-	protected $account;
+	protected Account\FioAccount $account;
 
 
 	public function __construct(Request\IQueue $queue, Account\FioAccount $account)

--- a/src/FioPay.php
+++ b/src/FioPay.php
@@ -16,14 +16,12 @@ class FioPay extends Fio
 	/** @var string */
 	private $uploadExtension;
 
-	/** @var string */
-	private $language = 'cs';
+	private string $language = 'cs';
 
 	/** @var IResponse */
 	private $response;
 
-	/** @var Pay\XMLFile */
-	private $xmlFile;
+	private Pay\XMLFile $xmlFile;
 
 	/** @var Log */
 	private $log;

--- a/src/FioRead.php
+++ b/src/FioRead.php
@@ -14,8 +14,7 @@ class FioRead extends Fio
 	/** @var string */
 	private $requestUrl;
 
-	/** @var Request\Read\IReader */
-	private $readerFactory;
+	private Request\Read\IReader $readerFactory;
 
 
 	public function __construct(Request\IQueue $queue, Account\FioAccount $account, Request\Read\IReader $readerFactory)

--- a/src/Request/IQueue.php
+++ b/src/Request/IQueue.php
@@ -6,8 +6,7 @@ use h4kuna\Fio\Response;
 
 interface IQueue
 {
-	/** @var int [s] */
-	const WAIT_TIME = 30;
+
 	const HEADER_CONFLICT = 409;
 
 

--- a/src/Request/Log.php
+++ b/src/Request/Log.php
@@ -6,8 +6,7 @@ use h4kuna\Fio\Exceptions\InvalidState;
 
 class Log
 {
-	/** @var string */
-	private $filename = '';
+	private string $filename = '';
 
 
 	public function setFilename(string $filename): void

--- a/src/Request/Pay/Payment/Euro.php
+++ b/src/Request/Pay/Payment/Euro.php
@@ -6,6 +6,7 @@ class Euro extends Foreign
 {
 	use Symbols;
 
+	/** @return array<string, bool> */
 	public function getExpectedProperty(): array
 	{
 		return [

--- a/src/Request/Pay/Payment/Foreign.php
+++ b/src/Request/Pay/Payment/Foreign.php
@@ -12,32 +12,23 @@ abstract class Foreign extends Property
 
 	private const TYPES_PAYMENT = [self::PAYMENT_STANDARD, self::PAYMENT_PRIORITY];
 
-	/** @var string */
-	protected $bic = '';
+	protected string $bic = '';
 
-	/** @var string */
-	protected $benefName = '';
+	protected string $benefName = '';
 
-	/** @var string */
-	protected $benefStreet = '';
+	protected string $benefStreet = '';
 
-	/** @var string */
-	protected $benefCity = '';
+	protected string $benefCity = '';
 
-	/** @var string */
-	protected $benefCountry = '';
+	protected string $benefCountry = '';
 
-	/** @var string */
-	protected $remittanceInfo1 = '';
+	protected string $remittanceInfo1 = '';
 
-	/** @var string */
-	protected $remittanceInfo2 = '';
+	protected string $remittanceInfo2 = '';
 
-	/** @var string */
-	protected $remittanceInfo3 = '';
+	protected string $remittanceInfo3 = '';
 
-	/** @var int */
-	protected $paymentType = 0;
+	protected int $paymentType = 0;
 
 
 	public function __construct(Account\FioAccount $account)
@@ -49,9 +40,8 @@ abstract class Foreign extends Property
 
 	/**
 	 * @param string $accountTo ISO 13616
-	 * @return static
 	 */
-	public function setAccountTo(string $accountTo)
+	public function setAccountTo(string $accountTo): static
 	{
 		$this->accountTo = InvalidArgument::check($accountTo, 34);
 		return $this;
@@ -60,39 +50,29 @@ abstract class Foreign extends Property
 
 	/**
 	 * @param string $bic ISO 9362
-	 * @return static
 	 */
-	public function setBic(string $bic)
+	public function setBic(string $bic): static
 	{
 		$this->bic = InvalidArgument::checkLength($bic, 11);
 		return $this;
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setStreet(string $street)
+	public function setStreet(string $street): static
 	{
 		$this->benefStreet = InvalidArgument::check($street, 35);
 		return $this;
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setCity(string $city)
+	public function setCity(string $city): static
 	{
 		$this->benefCity = InvalidArgument::check($city, 35);
 		return $this;
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setCountry(string $benefCountry)
+	public function setCountry(string $benefCountry): static
 	{
 		$country = strtoupper($benefCountry);
 		if (strlen($country) !== 2 && $country !== 'TCH') {
@@ -103,50 +83,35 @@ abstract class Foreign extends Property
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setName(string $name)
+	public function setName(string $name): static
 	{
 		$this->benefName = InvalidArgument::check($name, 35);
 		return $this;
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setRemittanceInfo1(string $info)
+	public function setRemittanceInfo1(string $info): static
 	{
 		$this->remittanceInfo1 = InvalidArgument::check($info, 35);
 		return $this;
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setRemittanceInfo2(string $info)
+	public function setRemittanceInfo2(string $info): static
 	{
 		$this->remittanceInfo2 = InvalidArgument::check($info, 35);
 		return $this;
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setRemittanceInfo3(string $str)
+	public function setRemittanceInfo3(string $str): static
 	{
 		$this->remittanceInfo3 = InvalidArgument::check($str, 35);
 		return $this;
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setPaymentType(int $type)
+	public function setPaymentType(int $type): static
 	{
 		$this->paymentType = InvalidArgument::checkIsInList($type, self::TYPES_PAYMENT);
 		return $this;

--- a/src/Request/Pay/Payment/International.php
+++ b/src/Request/Pay/Payment/International.php
@@ -12,14 +12,13 @@ class International extends Foreign
 
 	private const TYPES_CHARGES = [self::CHARGES_BEN, self::CHARGES_OUR, self::CHARGES_SHA];
 
-	/** @var string */
-	protected $remittanceInfo4 = '';
+	protected string $remittanceInfo4 = '';
 
 	/**
 	 * Default value is goods export.
 	 * @see Property
 	 */
-	protected $paymentReason = 110;
+	protected int $paymentReason = 110;
 
 	/** @var int */
 	protected $detailsOfCharges = self::CHARGES_BEN;
@@ -27,26 +26,23 @@ class International extends Foreign
 
 	/**
 	 * Section in manual 6.3.4.
-	 * @return static
 	 * @throws Exceptions\InvalidArgument
 	 */
-	public function setDetailsOfCharges(int $type)
+	public function setDetailsOfCharges(int $type): static
 	{
 		$this->detailsOfCharges = Exceptions\InvalidArgument::checkIsInList($type, self::TYPES_CHARGES);
 		return $this;
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setRemittanceInfo4(string $info)
+	public function setRemittanceInfo4(string $info): static
 	{
 		$this->remittanceInfo4 = Exceptions\InvalidArgument::check($info, 35);
 		return $this;
 	}
 
 
+	/** @return array<string, bool> */
 	public function getExpectedProperty(): array
 	{
 		return [

--- a/src/Request/Pay/Payment/National.php
+++ b/src/Request/Pay/Payment/National.php
@@ -14,48 +14,43 @@ class National extends Property
 
 	private const TYPES_PAYMENT = [self::PAYMENT_STANDARD, self::PAYMENT_PRIORITY, self::PAYMENT_COLLECTION];
 
-	/** @var string */
-	protected $bankCode = '';
+	protected string $bankCode = '';
 
-	/** @var string */
-	protected $messageForRecipient = '';
+	protected string $messageForRecipient = '';
 
 	/** @var int */
 	protected $paymentType = 0;
 
 
-	/** @return static */
-	public function setPaymentType(int $type)
+	public function setPaymentType(int $type): static
 	{
 		$this->paymentType = Exceptions\InvalidArgument::checkIsInList($type, self::TYPES_PAYMENT);;
 		return $this;
 	}
 
 
-	/** @return static */
-	public function setMessage(string $message)
+	public function setMessage(string $message): static
 	{
 		$this->messageForRecipient = Exceptions\InvalidArgument::check($message, 140);
 		return $this;
 	}
 
 
-	/** @return static */
-	public function setAccountTo(string $accountTo)
+	public function setAccountTo(string $accountTo): static
 	{
 		$this->accountTo = $accountTo;
 		return $this;
 	}
 
 
-	/** @return static */
-	public function setBankCode(string $bankCode)
+	public function setBankCode(string $bankCode): static
 	{
 		$this->bankCode = $bankCode;
 		return $this;
 	}
 
 
+	/** @return array<string, bool> */
 	public function getExpectedProperty(): array
 	{
 		return [

--- a/src/Request/Pay/Payment/Property.php
+++ b/src/Request/Pay/Payment/Property.php
@@ -12,17 +12,13 @@ use Nette\Utils\DateTime;
  */
 abstract class Property implements Iterator
 {
-	/** @var Account\FioAccount */
-	protected $accountFrom;
+	protected Account\FioAccount $accountFrom;
 
-	/** @var string */
-	protected $currency = 'CZK';
+	protected string $currency = 'CZK';
 
-	/** @var float */
-	protected $amount = 0.0;
+	protected float $amount = 0.0;
 
-	/** @var string */
-	protected $accountTo = '';
+	protected string $accountTo = '';
 
 	/** @var string */
 	protected $date;
@@ -34,13 +30,12 @@ abstract class Property implements Iterator
 	 * Section in manual 7.2.3.1.
 	 * @var int
 	 */
-	protected $paymentReason = 0;
+	protected int $paymentReason = 0;
 
 	/** @var array<string, array<string, bool>> */
-	private static $iterator = [];
+	private static array $iterator = [];
 
-	/** @var string */
-	private $key;
+	private ?string $key = null;
 
 
 	public function __construct(Account\FioAccount $account)
@@ -71,9 +66,8 @@ abstract class Property implements Iterator
 
 	/**
 	 * Currency code ISO 4217.
-	 * @return static
 	 */
-	public function setCurrency(string $code)
+	public function setCurrency(string $code): static
 	{
 		if (!preg_match('~[a-z]{3}~i', $code)) {
 			throw new InvalidArgument('Currency code must match ISO 4217.');
@@ -83,10 +77,7 @@ abstract class Property implements Iterator
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setMyComment(string $comment)
+	public function setMyComment(string $comment): static
 	{
 		$this->comment = InvalidArgument::check($comment, 255);
 		return $this;
@@ -95,19 +86,15 @@ abstract class Property implements Iterator
 
 	/**
 	 * @param int|string|\DateTimeInterface $date
-	 * @return static
 	 */
-	public function setDate($date)
+	public function setDate($date): static
 	{
 		$this->date = DateTime::from($date)->format('Y-m-d');
 		return $this;
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setPaymentReason(int $code)
+	public function setPaymentReason(int $code): static
 	{
 		$this->paymentReason = InvalidArgument::checkRange($code, 999);
 		return $this;
@@ -145,10 +132,7 @@ abstract class Property implements Iterator
 	 * *************************************************************************
 	 */
 
-	/**
-	 * @return mixed
-	 */
-	public function current()
+	public function current(): mixed
 	{
 		$property = $this->key();
 		$method = 'get' . ucfirst($property);
@@ -159,29 +143,26 @@ abstract class Property implements Iterator
 	}
 
 
-	/**
-	 * @return string
-	 */
-	public function key()
+	public function key(): string
 	{
 		return (string) key(self::$iterator[$this->key]);
 	}
 
 
-	public function next()
+	public function next(): void
 	{
 		next(self::$iterator[$this->key]);
 	}
 
 
-	public function rewind()
+	public function rewind(): void
 	{
 		$this->getProperties();
 		reset(self::$iterator[$this->key]);
 	}
 
 
-	public function valid()
+	public function valid(): bool
 	{
 		return array_key_exists($this->key(), self::$iterator[$this->key]);
 	}

--- a/src/Request/Pay/Payment/Symbols.php
+++ b/src/Request/Pay/Payment/Symbols.php
@@ -6,40 +6,28 @@ use h4kuna\Fio\Exceptions\InvalidArgument;
 
 trait Symbols
 {
-	/** @var int */
-	protected $ks = 0;
+	protected int $ks = 0;
 
-	/** @var int */
-	protected $vs = 0;
+	protected int $vs = 0;
 
-	/** @var int */
-	protected $ss = 0;
+	protected int $ss = 0;
 
 
-	/**
-	 * @return static
-	 */
-	public function setConstantSymbol(int $ks)
+	public function setConstantSymbol(int $ks): static
 	{
 		$this->ks = InvalidArgument::checkRange($ks, 9999);
 		return $this;
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setVariableSymbol(int $vs)
+	public function setVariableSymbol(int $vs): static
 	{
 		$this->vs = InvalidArgument::checkRange($vs, 9999999999);
 		return $this;
 	}
 
 
-	/**
-	 * @return static
-	 */
-	public function setSpecificSymbol(int $ss)
+	public function setSpecificSymbol(int $ss): static
 	{
 		$this->ss = InvalidArgument::checkRange($ss, 9999999999);
 		return $this;

--- a/src/Request/Pay/XMLFile.php
+++ b/src/Request/Pay/XMLFile.php
@@ -8,11 +8,9 @@ use XMLWriter;
 
 class XMLFile
 {
-	/** @var XMLWriter|null */
-	private $xml;
+	private ?XMLWriter $xml = null;
 
-	/** @var string */
-	private $temp;
+	private string $temp;
 
 
 	public function __construct(string $temp)
@@ -87,7 +85,7 @@ class XMLFile
 			}
 
 			$this->xml->startElement($node);
-			$this->xml->text((string) $value);
+			$this->xml->text((string) $value); /** @phpstan-ignore-line */
 			$this->xml->endElement();
 		}
 		$this->xml->endElement();

--- a/src/Request/Queue.php
+++ b/src/Request/Queue.php
@@ -10,20 +10,21 @@ use Psr\Http\Message\ResponseInterface;
 
 class Queue implements IQueue
 {
+
+	/** @var int [s] */
+	public const WAIT_TIME = 30;
+
 	/** @var string[] */
 	private static $tokens = [];
 
-	/** @var int */
-	private $limitLoop = 5;
+	private int $limitLoop = 5;
 
-	/** @var bool */
-	private $sleep = true;
+	private bool $sleep = true;
 
-	/** @var array<int, string> */
-	private $downloadOptions = [];
+	/** @var array<int|string, string> */
+	private array $downloadOptions = [];
 
-	/** @var string */
-	private $tempDir;
+	private string $tempDir;
 
 
 	public function __construct(string $tempDir)

--- a/src/Request/Read/Files/Json.php
+++ b/src/Request/Read/Files/Json.php
@@ -9,8 +9,7 @@ use Nette\Utils;
 
 class Json implements Request\Read\IReader
 {
-	/** @var Read\ITransactionListFactory */
-	private $transactionListFactory;
+	private Read\ITransactionListFactory $transactionListFactory;
 
 
 	public function __construct(Read\ITransactionListFactory $transactionListFactory)
@@ -47,13 +46,15 @@ class Json implements Request\Read\IReader
 			throw new Exceptions\ServiceUnavailable($e->getMessage(), 0, $e);
 		}
 
-		if (isset($json->accountStatement->info)) {
+		\assert($json instanceof \stdClass);
+
+		if (isset($json->accountStatement?->info)) {
 			$info = $this->transactionListFactory->createInfo($json->accountStatement->info, $dateFormat);
 		} else {
 			$info = new \stdClass();
 		}
 		$transactionList = $this->transactionListFactory->createTransactionList($info);
-		if (!isset($json->accountStatement->transactionList)) {
+		if (!isset($json->accountStatement?->transactionList)) {
 			return $transactionList;
 		}
 		foreach ($json->accountStatement->transactionList->transaction as $transactionData) {

--- a/src/Response/Pay/XMLResponse.php
+++ b/src/Response/Pay/XMLResponse.php
@@ -6,8 +6,7 @@ use SimpleXMLElement;
 
 class XMLResponse implements IResponse
 {
-	/** @var SimpleXMLElement */
-	private $xml;
+	private SimpleXMLElement $xml;
 
 
 	public function __construct(string $xml)

--- a/src/Response/Read/JsonTransactionFactory.php
+++ b/src/Response/Read/JsonTransactionFactory.php
@@ -7,16 +7,16 @@ use h4kuna\Fio\Utils;
 
 class JsonTransactionFactory implements ITransactionListFactory
 {
-	/** @var string[][] */
-	private $property;
+	/** @var string[][]|null */
+	private ?array $property = null;
 
-	/** @var string */
-	private $transactionClass;
+	/** @var class-string<TransactionAbstract> */
+	private string $transactionClass;
 
-	/** @var TransactionAbstract */
-	private $transactionObject;
+	private ?TransactionAbstract $transactionObject = null;
 
 
+	/** @param class-string<TransactionAbstract> $transactionClass */
 	public function __construct(string $transactionClass)
 	{
 		$this->transactionClass = $transactionClass;
@@ -51,12 +51,7 @@ class JsonTransactionFactory implements ITransactionListFactory
 	protected function createTransactionObject(string $dateFormat): TransactionAbstract
 	{
 		if ($this->transactionObject === null) {
-			$class = $this->transactionClass;
-			$this->transactionObject = new $class($dateFormat);
-
-			if (!$this->transactionObject instanceof TransactionAbstract) {
-				throw new Exceptions\Runtime(sprintf('Transaction class must extends "%s".', TransactionAbstract::class));
-			}
+			$this->transactionObject = new $this->transactionClass($dateFormat);
 		}
 
 		return clone $this->transactionObject;

--- a/src/Response/Read/TransactionAbstract.php
+++ b/src/Response/Read/TransactionAbstract.php
@@ -11,10 +11,9 @@ use h4kuna\Fio\Utils;
 abstract class TransactionAbstract implements \Iterator
 {
 	/** @var array<string, mixed> */
-	private $properties = [];
+	private array $properties = [];
 
-	/** @var string */
-	protected $dateFormat;
+	protected string $dateFormat;
 
 
 	public function __construct(string $dateFormat)
@@ -41,10 +40,7 @@ abstract class TransactionAbstract implements \Iterator
 	}
 
 
-	/**
-	 * @param mixed $value
-	 */
-	public function bindProperty(string $name, string $type, $value): void
+	public function bindProperty(string $name, string $type, mixed $value): void
 	{
 		$method = 'set' . ucfirst($name);
 		if (method_exists($this, $method)) {
@@ -56,11 +52,8 @@ abstract class TransactionAbstract implements \Iterator
 	}
 
 
-	/**
-	 * @return mixed
-	 */
 	#[\ReturnTypeWillChange]
-	public function current()
+	public function current(): mixed
 	{
 		return current($this->properties);
 	}
@@ -113,25 +106,16 @@ abstract class TransactionAbstract implements \Iterator
 	}
 
 
-	/**
-	 * @param mixed $value
-	 * @return mixed
-	 */
-	protected function checkValue($value, string $type)
+	protected function checkValue(mixed $value, string $type): mixed
 	{
-		switch ($type) {
-			case 'datetime':
-				return Utils\Strings::createFromFormat($value, $this->dateFormat);
-			case 'float':
-				return floatval($value);
-			case 'string':
-				return trim($value);
-			case 'int':
-				return intval($value);
-			case 'string|null':
-				return trim($value) ?: null;
-		}
-		return $value;
+		return match ($type) {
+			'datetime' => is_string($value) ? Utils\Strings::createFromFormat($value, $this->dateFormat) : $value,
+			'float' => floatval($value),
+			'string' => is_string($value) ? trim($value) : $value,
+			'int' => intval($value),
+			'string|null' => is_string($value) ? (trim($value) ?: null) : $value,
+			default => $value,
+		};
 	}
 
 }

--- a/src/Response/Read/TransactionList.php
+++ b/src/Response/Read/TransactionList.php
@@ -8,12 +8,9 @@ namespace h4kuna\Fio\Response\Read;
 final class TransactionList implements \Iterator, \Countable
 {
 	/** @var array<TransactionAbstract> */
-	private $transactions = [];
+	private array $transactions = [];
 
-	/**
-	 * @var \stdClass
-	 */
-	private $info;
+	private \stdClass $info;
 
 
 	public function __construct(\stdClass $info)
@@ -44,11 +41,7 @@ final class TransactionList implements \Iterator, \Countable
 	}
 
 
-	/**
-	 * @return int
-	 */
-	#[\ReturnTypeWillChange]
-	public function key()
+	public function key(): int
 	{
 		return (int) key($this->transactions);
 	}
@@ -68,16 +61,14 @@ final class TransactionList implements \Iterator, \Countable
 	}
 
 
-	#[\ReturnTypeWillChange]
-	public function valid()
+	public function valid(): bool
 	{
 		$key = key($this->transactions);
 		return $key !== null && isset($this->transactions[$key]);
 	}
 
 
-	#[\ReturnTypeWillChange]
-	public function count()
+	public function count(): int
 	{
 		return count($this->transactions);
 	}

--- a/src/Utils/FioFactory.php
+++ b/src/Utils/FioFactory.php
@@ -5,17 +5,16 @@ namespace h4kuna\Fio\Utils;
 use h4kuna\Fio;
 use h4kuna\Fio\Account;
 use h4kuna\Fio\Response\Read\Transaction;
+use h4kuna\Fio\Response\Read\TransactionAbstract;
 
 class FioFactory
 {
-	/** @var Account\AccountCollection */
-	private $accountCollection;
+	private Account\AccountCollection $accountCollection;
 
-	/** @var Fio\Request\IQueue */
-	private $queue;
+	private Fio\Request\IQueue $queue;
 
-	/** @var string */
-	private $transactionClass;
+	/** @var class-string<TransactionAbstract> */
+	private string $transactionClass;
 
 	/** @var string */
 	protected $temp;
@@ -23,6 +22,7 @@ class FioFactory
 
 	/**
 	 * @param array<array{token: string, account: string}> $accounts
+	 * @param class-string<TransactionAbstract> $transactionClass
 	 */
 	public function __construct(array $accounts, string $transactionClass = Transaction::class, string $temp = '')
 	{
@@ -92,6 +92,7 @@ class FioFactory
 	}
 
 
+	/** @return class-string<TransactionAbstract> */
 	final protected function transactionClass(): string
 	{
 		return $this->transactionClass;

--- a/tests/config/phpstan.neon
+++ b/tests/config/phpstan.neon
@@ -3,12 +3,3 @@ parameters:
 		- PHP_INT_SIZE
 	ignoreErrors:
 		# ignore for tests
-		-
-			message: "#^Parameter \\#1 \\$accounts of static method h4kuna\\\\Fio\\\\Account\\\\AccountCollectionFactory\\:\\:create\\(\\) expects array\\<array\\('token' \\=\\> string, 'account' \\=\\> string\\)\\>, array\\('foo' \\=\\> array\\('token' \\=\\> 'bar'\\)\\) given\\.$#"
-			count: 1
-			path: %rootDir%/../../../tests/src/Account/AccountCollectionTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$accounts of static method h4kuna\\\\Fio\\\\Account\\\\AccountCollectionFactory\\:\\:create\\(\\) expects array\\<array\\('token' \\=\\> string, 'account' \\=\\> string\\)\\>, array\\('foo' \\=\\> array\\('account' \\=\\> 'bar'\\)\\) given\\.$#"
-			count: 1
-			path: %rootDir%/../../../tests/src/Account/AccountCollectionTest.php

--- a/tests/data/Request.php
+++ b/tests/data/Request.php
@@ -9,103 +9,103 @@ use Psr\Http\Message\UriInterface;
 class Request implements RequestInterface
 {
 
-	public function getProtocolVersion()
+	public function getProtocolVersion(): string
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withProtocolVersion($version)
+	public function withProtocolVersion($version): Request
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getHeaders()
+	public function getHeaders(): array
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function hasHeader($name)
+	public function hasHeader($name): bool
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getHeader($name)
+	public function getHeader($name): array
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getHeaderLine($name)
+	public function getHeaderLine($name): string
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withHeader($name, $value)
+	public function withHeader($name, $value): Request
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withAddedHeader($name, $value)
+	public function withAddedHeader($name, $value): Request
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withoutHeader($name)
+	public function withoutHeader($name): Request
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getBody()
+	public function getBody(): StreamInterface
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withBody(StreamInterface $body)
+	public function withBody(StreamInterface $body): Request
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getRequestTarget()
+	public function getRequestTarget(): string
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withRequestTarget($requestTarget)
+	public function withRequestTarget($requestTarget): Request
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getMethod()
+	public function getMethod(): string
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withMethod($method)
+	public function withMethod($method): Request
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getUri()
+	public function getUri(): UriInterface
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withUri(UriInterface $uri, $preserveHost = false)
+	public function withUri(UriInterface $uri, $preserveHost = false): Request
 	{
 		throw new \RuntimeException('Not implemented.');
 	}

--- a/tests/data/Response.php
+++ b/tests/data/Response.php
@@ -11,18 +11,18 @@ class Response implements ResponseInterface
 	public const RESPONSE_CODE = 1;
 	public const EXCEPTION_CLASS = 2;
 
-	/** @var string */
-	private $method;
+	private string $method;
 
 	/** @var string|UriInterface */
 	private $uri;
 
-	/** @var array */
-	private $options = [];
+	/** @var mixed[] */
+	private array $options = [];
 
 
 	/**
 	 * @param string|UriInterface $uri
+	 * @param mixed[] $options
 	 */
 	public function __construct(string $method, $uri, array $options)
 	{
@@ -32,31 +32,31 @@ class Response implements ResponseInterface
 	}
 
 
-	public function getProtocolVersion()
+	public function getProtocolVersion(): string
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withProtocolVersion($version)
+	public function withProtocolVersion($version): Response
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getHeaders()
+	public function getHeaders(): array
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function hasHeader($name)
+	public function hasHeader($name): bool
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getHeader($name)
+	public function getHeader($name): array
 	{
 		if ('Content-Type' === $name) {
 			if ($this->isOk()) {
@@ -68,37 +68,37 @@ class Response implements ResponseInterface
 	}
 
 
-	public function getHeaderLine($name)
+	public function getHeaderLine($name): string
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withHeader($name, $value)
+	public function withHeader($name, $value): Response
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withAddedHeader($name, $value)
+	public function withAddedHeader($name, $value): Response
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function withoutHeader($name)
+	public function withoutHeader($name): Response
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getBody()
+	public function getBody(): Stream
 	{
 		return new Stream($this->isOk());
 	}
 
 
-	public function withBody(StreamInterface $body)
+	public function withBody(StreamInterface $body): Response
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
@@ -117,13 +117,13 @@ class Response implements ResponseInterface
 	}
 
 
-	public function withStatus($code, $reasonPhrase = '')
+	public function withStatus($code, $reasonPhrase = ''): Response
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getReasonPhrase()
+	public function getReasonPhrase(): string
 	{
 		throw new \RuntimeException('Not implemented.');
 	}

--- a/tests/data/Stream.php
+++ b/tests/data/Stream.php
@@ -7,8 +7,7 @@ use Salamium\Testinium\File;
 
 class Stream implements StreamInterface
 {
-	/** @var bool */
-	private $isOk;
+	private bool $isOk;
 
 
 	public function __construct(bool $failed)
@@ -35,25 +34,25 @@ class Stream implements StreamInterface
 	}
 
 
-	public function getSize()
+	public function getSize(): ?int
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function tell()
+	public function tell(): int
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function eof()
+	public function eof(): bool
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function isSeekable()
+	public function isSeekable(): bool
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
@@ -71,31 +70,31 @@ class Stream implements StreamInterface
 	}
 
 
-	public function isWritable()
+	public function isWritable(): bool
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function write($string)
+	public function write($string): int
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function isReadable()
+	public function isReadable(): bool
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function read($length)
+	public function read($length): string
 	{
 		throw new \RuntimeException('Not implemented.');
 	}
 
 
-	public function getContents()
+	public function getContents(): bool|string
 	{
 		return File::load(sprintf('payment/response%s.xml', $this->isOk ? '' : '-error'));
 	}

--- a/tests/src/Account/AccountCollectionTest.php
+++ b/tests/src/Account/AccountCollectionTest.php
@@ -94,6 +94,7 @@ class AccountCollectionTest extends Test\TestCase
 	public function testAccounCollectionFactoryThrowAccount(): void
 	{
 		Assert::throws(function () {
+			/** @phpstan-ignore-next-line */
 			AccountCollectionFactory::create([
 				'foo' => [
 					'token' => 'bar',
@@ -106,6 +107,7 @@ class AccountCollectionTest extends Test\TestCase
 	public function testAccounCollectionFactoryThrowToken(): void
 	{
 		Assert::throws(function () {
+			/** @phpstan-ignore-next-line */
 			AccountCollectionFactory::create([
 				'foo' => [
 					'account' => 'bar',

--- a/tests/src/Response/Read/JsonStatementFactoryTest.php
+++ b/tests/src/Response/Read/JsonStatementFactoryTest.php
@@ -28,16 +28,6 @@ final class JsonStatementFactoryTest extends Test\TestCase
 		}
 	}
 
-
-	/**
-	 * @throws \h4kuna\Fio\Exceptions\Runtime
-	 */
-	public function testThrow(): void
-	{
-		$factory = new JsonTransactionFactory(WrongTransaction::class);
-		$factory->createTransaction(new \stdClass(), 'Y');
-	}
-
 }
 
 final class WrongTransaction extends \stdClass


### PR DESCRIPTION
This PR contributes to a new 3.0 version (#46)
- support for PHP 8.0+
- some annotations replaced by type hints
- updated PHPStan and fixed errors