### PR TITLE
Fix assertion error when stringable object is not scalar

### DIFF
--- a/src/Pay/XMLFile.php
+++ b/src/Pay/XMLFile.php
@@ -63,7 +63,7 @@ class XMLFile
 				$value = '';
 			}
 
-			assert(is_scalar($value));
+			assert(is_scalar($value) || $value instanceof \Stringable);
 			$this->xml->startElement($node);
 			$this->xml->text(strval($value));
 			$this->xml->endElement();


### PR DESCRIPTION
Class `h4kuna\Fio\Account\FioAccount` is not scalar and `assert(is_scalar($value))` failing