### PR TITLE
AccountCollectionFactory.php: explicitly cast $alias to string

### DIFF
--- a/src/Account/AccountCollectionFactory.php
+++ b/src/Account/AccountCollectionFactory.php
@@ -19,7 +19,7 @@ class AccountCollectionFactory
 			} elseif (!isset($info['account']) || $info['account'] === '') { /* @phpstan-ignore-line */
 				throw new Exceptions\InvalidArgument(sprintf('Key "account" is required for alias "%s".', $alias));
 			}
-			$accountCollection->addAccount($alias, new FioAccount($info['account'], $info['token']));
+			$accountCollection->addAccount((string) $alias, new FioAccount($info['account'], $info['token']));
 		}
 
 		return $accountCollection;


### PR DESCRIPTION
with NEON definition like this

```
parameters:
	bankAccounts:
		# this is internal ID
		'2':
			account: 'accountNumber'
			token: 'secretToken'
```

Neon parses '2' as `int` value of `2` and the code breaks. I need to use these internal IDs as shown above